### PR TITLE
fix article number creation

### DIFF
--- a/application/converter/mf_sdk_converter.php
+++ b/application/converter/mf_sdk_converter.php
@@ -141,7 +141,6 @@ class mf_sdk_converter implements mf_converter_interface
         $currency = array_shift($currency);
         $rate = $currency->rate;
 
-        $aParams['oxarticles__oxartnum'] = $this->generateArtNum();
         $aParams['oxarticles__oxean'] = $object->ean;
         $aParams['oxarticles__oxexturl'] = $object->url;
         $aParams['oxarticles__oxtitle'] = $object->title;
@@ -327,12 +326,6 @@ class mf_sdk_converter implements mf_converter_interface
         $purchaseGroupChar = strtolower($purchaseGroupChar);
 
         return 'oxarticles__oxprice'.$purchaseGroupChar;
-    }
-
-    private function generateArtNum()
-    {
-
-        return 'BEP-' . mt_rand(0,9999) . '-' . mt_rand(0,9999);
     }
 
     private function getModuleHelper()

--- a/application/helper/mf_article_number_generator.php
+++ b/application/helper/mf_article_number_generator.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Base article number generator.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class mf_article_number_generator
+{
+    /**
+     * We just creating a some random numbers in here.
+     */
+    public function generate()
+    {
+        return 'BEP-' . mt_rand(0,9999) . '-' . mt_rand(0,9999);
+    }
+}

--- a/application/models/productToShop.php
+++ b/application/models/productToShop.php
@@ -138,9 +138,12 @@ class oxidProductToShop implements ProductToShop
      */
     private function insertArticleWithBepadoState(oxArticle $oxArticle, oxBase $oBepadoProductState, Struct\Product $product)
     {
+        /** @var mf_article_number_generator $articleNumberGenerator */
+        $articleNumberGenerator = $this->getVersionLayer()->createNewObject('mf_article_number_generator');
         $oxArticle->assign(array(
-            'oxarticles__oxactive' => 0,
+            'oxarticles__oxactive'    => 0,
             'oxarticles__oxstockflag' => 3,
+            'oxarticles__oxartnum'    => $articleNumberGenerator->generate(),
 
         ));
         $oxArticle->save();

--- a/metadata.php
+++ b/metadata.php
@@ -64,13 +64,14 @@ $aModule = array(
         'VersionLayer500'       => $aPaths['core'] . '/VersionLayer500.php',
         'VersionLayerFactory'   => $aPaths['core'] . '/VersionLayerFactory.php',
 
-        'mf_abstract_helper'    => $aPaths['helper'] . '/mf_abstract_helper.php',
-        'mf_sdk_helper'         => $aPaths['helper'] . '/mf_sdk_helper.php',
-        'mf_sdk_product_helper' => $aPaths['helper'] . '/mf_sdk_product_helper.php',
-        'mf_sdk_logger_helper'  => $aPaths['helper'] . '/mf_sdk_logger_helper.php',
-        'mf_sdk_article_helper' => $aPaths['helper'] . '/mf_sdk_article_helper.php',
-        'mf_sdk_order_helper'   => $aPaths['helper'] . '/mf_sdk_order_helper.php',
-        'mf_module_helper'      => $aPaths['helper'] . '/mf_module_helper.php',
+        'mf_abstract_helper'          => $aPaths['helper'] . '/mf_abstract_helper.php',
+        'mf_sdk_helper'               => $aPaths['helper'] . '/mf_sdk_helper.php',
+        'mf_sdk_product_helper'       => $aPaths['helper'] . '/mf_sdk_product_helper.php',
+        'mf_sdk_logger_helper'        => $aPaths['helper'] . '/mf_sdk_logger_helper.php',
+        'mf_sdk_article_helper'       => $aPaths['helper'] . '/mf_sdk_article_helper.php',
+        'mf_sdk_order_helper'         => $aPaths['helper'] . '/mf_sdk_order_helper.php',
+        'mf_module_helper'            => $aPaths['helper'] . '/mf_module_helper.php',
+        'mf_article_number_generator' => $aPaths['helper'] . '/mf_article_number_generator.php',
     ),
     'blocks' => array(
         array(


### PR DESCRIPTION
Die artickelNumber wird jetzt durch einen eigenen (überschreibbaren) Service gebaut. Per Test gehen wir jetzt sicher, dass die Methode nur auf `insert` aufgerufen wird, damit sollte es vorrüber sein mit wechselnden Artikelnummern von Fremden Artikeln.

Dabei habe ich noch ein paar andere Tests gefixed. Das sind folgen aus adhoc Spielereien an den Staging-Systemen.
