### PR TITLE
List imported/exported articles in admin section

### DIFF
--- a/application/controllers/admin/mf_category_main.php
+++ b/application/controllers/admin/mf_category_main.php
@@ -70,7 +70,7 @@ class mf_category_main extends mf_category_main_parent
         $myConfig = parent::getConfig();
         $oxidCategoryId = parent::getEditObjectId();
 
-        /** @var oxBase $bepadoCategory */
+        /** @var mfBepadoProduct $bepadoCategory */
         $bepadoCategory = oxNew('oxbase');
         $bepadoCategory->init('bepado_categories');
         $query = $bepadoCategory->buildSelectString(array('catnid' => $oxidCategoryId));

--- a/application/controllers/admin/mf_product_admin_list.php
+++ b/application/controllers/admin/mf_product_admin_list.php
@@ -1,0 +1,101 @@
+<?php
+
+/**
+ * Just some abstraction for both mf_product_..._list classes as we have some common logic in there.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class mf_product_admin_list extends oxAdminList
+{
+    /**
+     * @var VersionLayerInterface
+     */
+    protected $_oVersionLayer;
+
+    /**
+     * A list of shops with its keys.
+     *
+     * @var array
+     */
+    protected $shops = array();
+
+    /**
+     * Each of the shops got its configuration in the bepado system.
+     * So this method asks the sdk for getting them.
+     * To avoid multiple requests, we do cache them.
+     *
+     * @param $shopId
+     *
+     * @return Shop
+     */
+    public function getShopById($shopId)
+    {
+        if (isset($this->shops[$shopId])) {
+            return $this->shops[$shopId];
+        }
+        /** @var mf_sdk_helper $sdkHelper */
+        $sdkHelper = $this->getVersionLayer()->createNewObject('mf_sdk_helper');
+        $sdk = $sdkHelper->instantiateSdk();
+        $shop = $sdk->getShop($shopId);
+        // for unknown shops
+        if (null === $shop->name) {
+            $shop->name = 'Unknown';
+        }
+        $this->shops[$shopId] = $shop;
+
+        return $shop;
+    }
+
+    /**
+     * @param VersionLayerInterface $versionLayer
+     */
+    public function setVersionLayer(VersionLayerInterface $versionLayer)
+    {
+        $this->_oVersionLayer = $versionLayer;
+    }
+
+    /**
+     * Create and/or returns the VersionLayer.
+     *
+     * @return VersionLayerInterface
+     */
+    protected function getVersionLayer()
+    {
+        if (null == $this->_oVersionLayer) {
+            /** @var VersionLayerFactory $factory */
+            $factory = oxNew('VersionLayerFactory');
+            $this->_oVersionLayer = $factory->create();
+        }
+
+        return $this->_oVersionLayer;
+    }
+
+    /**
+     * Depending on the state this method filters a list of oxArticles.
+     *
+     * In the list of exported articles these should be shown only. Same for
+     * the list of imported articles. They are filtered by their entries in
+     * our mfbepadoproducts table.
+     *
+     * @param array|mfBepadoProduct $list
+     * @param int   $state
+     *
+     * @return array
+     */
+    protected function filterArticlesByState($list, $state)
+    {
+        foreach ($list as $key => $item)  {
+            if ($item->getState() !== $state) {
+                unset($list[$key]);
+                continue;
+            }
+
+            /** @var oxArticle $oArticle */
+            $oArticle = $this->getVersionLayer()->createNewObject('oxArticle');
+            $oArticle->load($item->mfbepadoproducts__oxid->value);
+            $list[$key]->setOxArticle($oArticle);
+        }
+
+        return $list;
+    }
+}

--- a/application/controllers/admin/mf_product_export_list.php
+++ b/application/controllers/admin/mf_product_export_list.php
@@ -19,7 +19,35 @@
  *
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_export_list extends oxAdminList
+class mf_product_export_list extends mf_product_admin_list
 {
+    /**
+     * Which is the base model to use for this list.
+     *
+     * @var string
+     */
+    protected $_sListClass = 'mfBepadoProduct';
+
+    /**
+     * Decides which template is chose for this list.
+     *
+     * @var string
+     */
     protected $_sThisTemplate = 'mf_product_export_list.tpl';
+
+    /**
+     * We need to enrich the data of the mfBepadoProduct model by its
+     * oxid article representation.
+     */
+    public function render()
+    {
+        $sParent = parent::render();
+
+        $this->_aViewData['mylist'] = $this->filterArticlesByState(
+            $this->_aViewData['mylist'],
+            mfBepadoProduct::PRODUCT_STATE_EXPORTED
+        );
+
+        return $sParent;
+    }
 }

--- a/application/controllers/admin/mf_product_export_main.php
+++ b/application/controllers/admin/mf_product_export_main.php
@@ -13,6 +13,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
+use Bepado\SDK\Exception\VerificationFailedException;
 
 /**
  * This controller will render the main view of the exported products admin.
@@ -21,10 +22,197 @@
  */
 class mf_product_export_main extends oxAdminDetails
 {
+    /**
+     * Unit array
+     *
+     * @var array
+     */
+    protected $_aUnitsArray = null;
+
+    /**
+     * @var VersionLayerInterface
+     */
+    protected $_oVersionLayer;
+
     public function render()
     {
         parent::render();
 
+        $oBepadoProduct = $this->getVersionLayer()->createNewObject('mfBepadoProduct');
+        $this->_aViewData['updatelist'] = true;
+        $this->_aViewData['edit'] = new \stdClass();
+        $this->_aViewData['edit']->mfBepadoProduct = $oBepadoProduct;
+
+        $oxId = $this->getEditObjectId();
+        if ($oxId && '-1' !== $oxId) {
+            $oBepadoProduct->load($oxId);
+        }
+
+        $oArticle = $this->getVersionLayer()->createNewObject('oxArticle');
+        $oArticle->load($oBepadoProduct->mfbepadoproducts__oxid->value);
+        $this->_aViewData['edit']->oxArticle = $oArticle;
+        $this->_aViewData["editor"] = $this->_generateTextEditor(
+            "100%",
+            300,
+            $oArticle,
+            "oxarticles__oxlongdesc",
+            "details.tpl.css"
+        );
+        $this->_aViewData['edit']->oArticleHelper = $this->getVersionLayer()->createNewObject('mf_sdk_article_helper');
+
         return 'mf_product_export_main.tpl';
+    }
+
+    /**
+     * When saving a bepado product model, we will save the allowed values of the oxid article representation.
+     */
+    public function save()
+    {
+        $aParams = $this->getVersionLayer()->getConfig()->getRequestParameter("editval");
+
+        if (isset($aParams['articleToExport'])) {
+            $oBepadoProduct = $this->getVersionLayer()->createNewObject('mfBepadoProduct');
+            $oBepadoProduct->assign(array(
+                    'p_source_id' => $aParams['articleToExport'],
+                    'OXID'        => $aParams['articleToExport'],
+                    'shop_id'     => '_self_',
+                    'state'       => mfBepadoConfiguration::ARTICLE_STATE_EXPORTED,
+                )
+            );
+            $oBepadoProduct->save();
+            try {
+                /** @var mf_sdk_helper $sdkHelper */
+                $sdkHelper = $this->getVersionLayer()->createNewObject('mf_sdk_helper');
+                $sdkHelper->instantiateSdk()->recordInsert($aParams['articleToExport']);
+            } catch (VerificationFailedException $e) {
+                $oBepadoProduct->delete();
+                $this->_aViewData['errorExportingArticle'] = true;
+                $this->_aViewData['errorMessage'] = $e->getMessage();
+            }
+
+            return;
+        }
+
+        parent::save();
+
+        $oArticle = $this->getVersionLayer()->createNewObject('oxArticle');
+        /** @var oxArticle $oArticle the id of the bepado product model and the oxid article representation is the same */
+        $oArticle->load($this->getEditObjectId());
+        $oArticle->assign($aParams['oxArticle']);
+        $oArticle->setArticleLongDesc($aParams['oxarticles__oxlongdesc']);
+
+        $oArticle->save();
+    }
+
+    /**
+     * @param VersionLayerInterface $versionLayer
+     */
+    public function setVersionLayer(VersionLayerInterface $versionLayer)
+    {
+        $this->_oVersionLayer = $versionLayer;
+    }
+
+    /**
+     * Create and/or returns the VersionLayer.
+     *
+     * @return VersionLayerInterface
+     */
+    private function getVersionLayer()
+    {
+        if (null == $this->_oVersionLayer) {
+            /** @var VersionLayerFactory $factory */
+            $factory = oxNew('VersionLayerFactory');
+            $this->_oVersionLayer = $factory->create();
+        }
+
+        return $this->_oVersionLayer;
+    }
+
+    /**
+     * Returns string which must be edited by editor
+     *
+     * @param mfBepadoProduct $oObject object whifh field will be used for editing
+     * @param string $sField  name of editable field
+     *
+     * @return string
+     */
+    protected function _getEditValue($oObject, $sField)
+    {
+        $sEditObjectValue = '';
+        if ($oObject) {
+            $oDescField = $oObject->getLongDescription();
+            $sEditObjectValue = $this->_processEditValue($oDescField->getRawValue());
+        }
+
+        return $sEditObjectValue;
+    }
+
+    /**
+     * Returns shop manufacturers list
+     *
+     * @return oxmanufacturerlist
+     */
+    public function getVendorList()
+    {
+        $oVendorlist = $this->getVersionLayer()->createNewObject('oxVendorList');
+        $oVendorlist->loadVendorList();
+
+        return $oVendorlist;
+    }
+
+    /**
+     * Returns array of possible unit combination and its translation for edit language
+     *
+     * @return array
+     */
+    public function getUnitsArray()
+    {
+        if ($this->_aUnitsArray === null) {
+            $this->_aUnitsArray = oxRegistry::getLang()->getSimilarByKey("_UNIT_", $this->_iEditLang, false);
+        }
+
+        return $this->_aUnitsArray;
+    }
+
+    public function getArticlesToExport()
+    {
+        $oDb = $this->getVersionLayer()->getDb(true);
+
+        /** @var oxArticleList $oArticleList */
+        $oArticleList = $this->getVersionLayer()->createNewObject('oxArticleList');
+        $oArticleList->clear();
+        $oArticleList->init('oxArticle');
+
+        $oArticleListObject = $oArticleList->getBaseObject();
+        if ($oArticleListObject->isMultilang()) {
+            $oArticleListObject->setLanguage(oxRegistry::getLang()->getBaseLanguage());
+        }
+
+        $sTable = getViewName("oxarticles");
+        $sSelectString = $oArticleListObject->buildSelectString(array($sTable.'.oxparentid' => null));
+        $oArticleList->selectString($sSelectString);
+        $aArticleKeys = $oArticleList->getArray();
+
+        /** @var oxList $oBepadoProductsList */
+        $oBepadoProductsList = $this->getVersionLayer()->createNewObject('oxList');
+        $oBepadoProductsList->clear();
+        $oBepadoProductsList->init('mfBepadoProduct');
+        $oBepadoProductsListObject = $oBepadoProductsList->getBaseObject();
+        $sSelectString = $oBepadoProductsListObject->buildSelectString();
+        $oBepadoProductsList->selectString($sSelectString);
+        $aBepadoProductKeys = $oBepadoProductsList->getArray();
+
+        $notExportedArticles = array_diff_key($aArticleKeys, $aBepadoProductKeys);
+
+        $sPwrSearchFld = $this->getVersionLayer()->getConfig()->getRequestParameter('pwrsearchfld');
+        $sPwrSearchFld = $sPwrSearchFld ? strtolower($sPwrSearchFld) : "oxtitle";
+
+        foreach ($notExportedArticles as $key => $oArticle) {
+            $sFieldName = "oxarticles__{$sPwrSearchFld}";
+            $oArticle->pwrsearchval = $oArticle->$sFieldName->value;
+            $oList[$key] = $oArticle;
+        }
+
+        return $notExportedArticles;
     }
 }

--- a/application/controllers/admin/mf_product_import_list.php
+++ b/application/controllers/admin/mf_product_import_list.php
@@ -19,7 +19,35 @@
  *
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_import_list extends oxAdminList
+class mf_product_import_list extends mf_product_admin_list
 {
+    /**
+     * Which is the base model to use for this list.
+     *
+     * @var string
+     */
+    protected $_sListClass = 'mfBepadoProduct';
+
+    /**
+     * Decides which template is chose for this list.
+     *
+     * @var string
+     */
     protected $_sThisTemplate = 'mf_product_import_list.tpl';
+
+    /**
+     * We need to enrich the data of the mfBepadoProduct model by its
+     * oxid article representation.
+     */
+    public function render()
+    {
+        $sParent = parent::render();
+
+        $this->_aViewData['mylist'] = $this->filterArticlesByState(
+            $this->_aViewData['mylist'],
+            mfBepadoProduct::PRODUCT_STATE_IMPORTED
+        );
+
+        return $sParent;
+    }
 }

--- a/application/controllers/admin/mf_product_import_main.php
+++ b/application/controllers/admin/mf_product_import_main.php
@@ -21,10 +21,131 @@
  */
 class mf_product_import_main extends oxAdminDetails
 {
+    /**
+     * Unit array
+     *
+     * @var array
+     */
+    protected $_aUnitsArray = null;
+
+    /**
+     * @var VersionLayerInterface
+     */
+    protected $_oVersionLayer;
+
     public function render()
     {
         parent::render();
 
+        $oBepadoProduct = $this->getVersionLayer()->createNewObject('mfBepadoProduct');
+        $this->_aViewData['edit'] = new \stdClass();
+        $this->_aViewData['edit']->mfBepadoProduct = $oBepadoProduct;
+
+        $oxId = $this->getEditObjectId();
+        if ($oxId && '-1' !== $oxId) {
+            $oBepadoProduct->load($oxId);
+        }
+
+        $oArticle = $this->getVersionLayer()->createNewObject('oxArticle');
+        $oArticle->load($oBepadoProduct->mfbepadoproducts__oxid->value);
+        $this->_aViewData['edit']->oxArticle = $oArticle;
+        $this->_aViewData["editor"] = $this->_generateTextEditor(
+            "100%",
+            300,
+            $oArticle,
+            "oxarticles__oxlongdesc",
+            "details.tpl.css"
+        );
+        $this->_aViewData['edit']->oArticleHelper = $this->getVersionLayer()->createNewObject('mf_sdk_article_helper');
+
         return 'mf_product_import_main.tpl';
+    }
+
+    /**
+     * When saving a bepado product model, we will save the allowed values of the oxid article representation.
+     */
+    public function save()
+    {
+        parent::save();
+
+        $aParams = $this->getVersionLayer()->getConfig()->getRequestParameter("editval");
+
+        $oArticle = $this->getVersionLayer()->createNewObject('oxArticle');
+        /** @var oxArticle $oArticle the id of the bepado product model and the oxid article representation is the same */
+        $oArticle->load($this->getEditObjectId());
+        $oArticle->assign($aParams['oxArticle']);
+        $oArticle->setArticleLongDesc($aParams['oxarticles__oxlongdesc']);
+
+        $oArticle->save();
+    }
+
+    /**
+     * @param VersionLayerInterface $versionLayer
+     */
+    public function setVersionLayer(VersionLayerInterface $versionLayer)
+    {
+        $this->_oVersionLayer = $versionLayer;
+    }
+
+    /**
+     * Create and/or returns the VersionLayer.
+     *
+     * @return VersionLayerInterface
+     */
+    private function getVersionLayer()
+    {
+        if (null == $this->_oVersionLayer) {
+            /** @var VersionLayerFactory $factory */
+            $factory = oxNew('VersionLayerFactory');
+            $this->_oVersionLayer = $factory->create();
+        }
+
+        return $this->_oVersionLayer;
+    }
+
+    /**
+     * Returns string which must be edited by editor
+     *
+     * @param mfBepadoProduct $oObject object whifh field will be used for editing
+     * @param string $sField  name of editable field
+     *
+     * @return string
+     */
+    protected function _getEditValue($oObject, $sField)
+    {
+        $sEditObjectValue = '';
+        if ($oObject) {
+            $oDescField = $oObject->getLongDescription();
+            $sEditObjectValue = $this->_processEditValue($oDescField->getRawValue());
+        }
+
+        return $sEditObjectValue;
+    }
+
+    /**
+     * Returns shop manufacturers list
+     *
+     * @return oxmanufacturerlist
+     */
+    public function getVendorList()
+    {
+        $oVendorlist = $this->getVersionLayer()->createNewObject('oxVendorList');
+        $oVendorlist->loadVendorList();
+
+        return $oVendorlist;
+    }
+
+    /**
+     * Returns array of possible unit combination and its translation for edit language
+     *
+     * @return array
+     */
+    public function getUnitsArray()
+    {
+        if ($this->_aUnitsArray === null) {
+            $this->_aUnitsArray = oxRegistry::getLang()->getSimilarByKey("_UNIT_", $this->_iEditLang, false);
+        }
+
+        return $this->_aUnitsArray;
     }
 }

--- a/application/converter/mf_sdk_address_converter.php
+++ b/application/converter/mf_sdk_address_converter.php
@@ -62,7 +62,7 @@ class mf_sdk_address_converter extends mf_abstract_converter implements mf_conve
      * prefix for the oxAddress field names. So we will create an array for assigning the
      * values first.
      *
-     * @param oxBase $object
+     * @param mfBepadoProduct $object
      *
      * @return Struct\Address|array
      */

--- a/application/install/mf_bepado.sql
+++ b/application/install/mf_bepado.sql
@@ -12,7 +12,7 @@
  * GNU General Public License for more details.
  */
 
-CREATE TABLE IF NOT EXISTS `bepado_product_state` (
+CREATE TABLE IF NOT EXISTS `mfbepadoproducts` (
   `OXID` VARCHAR(32),
   `p_source_id` VARCHAR(64) NOT NULL,
   `shop_id` VARCHAR(64) NOT NULL,

--- a/application/models/mfBepadoProduct.php
+++ b/application/models/mfBepadoProduct.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * The model class for an imported/exported product.
+ * Each of them will have an oxArticle representation too.
+ *
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class mfBepadoProduct extends oxBase
+{
+    const PRODUCT_STATE_NONE = 0;
+    const PRODUCT_STATE_EXPORTED = 1;
+    const PRODUCT_STATE_IMPORTED = 2;
+    const DATABASE_BASE_STRING = 'mfbepadoproducts__';
+
+    /**
+     * As every bepado product simply is a representation of an oxid article, we will link them.
+     *
+     * @var oxArticle
+     */
+    private $oxArticle;
+
+    public function __construct()
+    {
+        parent::init('mfbepadoproducts');
+    }
+
+    /**
+     * Setter for the state of an bepado product.
+     *
+     * This state can only be 1 (exported) or 2 (imported).
+     *
+     * @param $state
+     *
+     * @return mfBepadoProduct
+     */
+    public function setState($state)
+    {
+        $states = array(
+            self::PRODUCT_STATE_EXPORTED,
+            self::PRODUCT_STATE_IMPORTED
+        );
+        if (!in_array($state, $states)) {
+          throw new InvalidArgumentException(
+              sprintf("Product state %s is not supported. Use one of %s.", $state, implode(',', $states))
+          );
+        }
+
+        $this->_setFieldData(self::DATABASE_BASE_STRING.'state', $state);
+
+        return $this;
+    }
+
+    /**
+     * The state is casted to an integer.
+     *
+     * The method will answer with one of the allowed states only.
+     *
+     * @return int
+     */
+    public function getState()
+    {
+        $states = array(
+            self::PRODUCT_STATE_EXPORTED,
+            self::PRODUCT_STATE_IMPORTED
+        );
+        $state = (int) $this->getFieldData(self::DATABASE_BASE_STRING.'state');
+        if (!in_array($state, $states)) {
+            return self::PRODUCT_STATE_NONE;
+        }
+
+        return $state;
+    }
+
+    /**
+     * Setter for the shopId of the related sdk product.
+     *
+     * @param int $shopId
+     *
+     * @return $this
+     */
+    public function setShopId($shopId)
+    {
+        $this->_setFieldData(self::DATABASE_BASE_STRING.'shop_id', $shopId);
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getShopId()
+    {
+        return $this->getFieldData(self::DATABASE_BASE_STRING.'shop_id');
+    }
+
+    /**
+     * The product Id in the source shop.
+     *
+     * @param $productId
+     *
+     * @return $this
+     */
+    public function setProductSourceId($productId)
+    {
+        $this->_setFieldData(self::DATABASE_BASE_STRING.'p_source_id', $productId);
+
+        return $this;
+    }
+
+    /**
+     * @return int
+     */
+    public function getProductSourceId()
+    {
+        return $this->getFieldData(self::DATABASE_BASE_STRING.'p_source_id');
+    }
+
+    /**
+     * @param oxArticle $article
+     */
+    public function setOxArticle(oxArticle $article)
+    {
+        $this->oxArticle = $article;
+    }
+
+    /**
+     * @return oxArticle
+     */
+    public function getOxArticle()
+    {
+        return $this->oxArticle;
+    }
+}

--- a/application/models/productFromShop.php
+++ b/application/models/productFromShop.php
@@ -77,7 +77,7 @@ class oxidProductFromShop implements ProductFromShop
     public function getExportedProductIDs()
     {
         $ids = array();
-        $sql = "SELECT p_source_id FROM bepado_product_state WHERE state = ".mfBepadoConfiguration::ARTICLE_STATE_EXPORTED;
+        $sql = "SELECT p_source_id FROM mfbepadoproducts WHERE state = ".mfBepadoConfiguration::ARTICLE_STATE_EXPORTED;
         $list = $this->getVersionLayer()->getDb(true)->execute($sql);
 
         while (!$list->EOF) {

--- a/application/views/admin/de/bepado_lang.php
+++ b/application/views/admin/de/bepado_lang.php
@@ -80,9 +80,59 @@ $aLang = array(
     'HELP_MF_BEPADO_OXID_UNIT_KEY'                    => 'OXID Maßeinheit haben Sie über ihre Übersetzungen definiert. Es werden bereits verwendete heraus gefiltert.',
     'HELP_MF_BEPADO_BEPADO_UNIT_KEY'                  => 'Die Maßeinheit im Bepado Netzwerk',
     'MF_BEPADO_CONFIGURATION_UNIT_HINT_LEGEND'        => 'Hinweise zum Maßeinheiten-Mapping',
-    'MF_BEPADO_CONFIGURATION_UNIT_HINT'               => '
-        <p>In beiden Auswahlfeldern werden Ihnen immer nur die Einheiten angezeigt, die noch zu vergeben sind.</p>
+    'MF_BEPADO_CONFIGURATION_UNIT_HINT'               => '<p>In beiden Auswahlfeldern werden Ihnen immer nur die Einheiten angezeigt, die noch zu vergeben sind.</p>
         <p>Das heißt haben Sie all Ihren OXID-Einheiten eine Bepado-Einheit zugewisen, können Sie keine weitere Zuweisung vornehmen.<br />
         Außerdem ist es nur möglich folgende Bepado-Einheiten auszuwählen:</p>',
-    'MF_BEPADO_UNIT_NO_SELECT'                         => 'Wählen Sie eine Einheit ...'
+    'MF_BEPADO_UNIT_NO_SELECT'                        => 'Wählen Sie eine Einheit ...',
+    'MF_BEPADO_SHOP_ID'                               => 'Shop-ID',
+    'MF_BEPADO_PRODUCT_SOURCE_ID'                     => 'Product-ID',
+    'MF_BEPADO_ARTICLE_TITLE'                         => 'Produktname',
+    'MF_PRODUCT_IMPORT_TITLE'                         => 'Titel',
+    'HELP_MF_PRODUCT_IMPORT_TITLE'                    => '<p>Titel des importierten Produkts.</p>
+        <p>Wird bei jeder Syncronisation mit den Originaldaten überschrieben.</p>',
+    'HELP_MF_BEPADO_PRODUCT_IMPORT_SHORTDESCRIPTION'  => '<p>Kurzbeschreibung des importierten Produkts.</p>
+        <p>Wird bei jeder Syncronisation mit den Originaldaten überschrieben.</p>',
+    'HELP_MF_PRODUCT_IMPORT_EAN'                      => '
+        <p> Die Artikelnummer (EAN) des importierten Produkts</p>
+        <p>Wird bei jeder Syncronisation mit den Originaldaten überschrieben.</p>
+    ',
+    'HELP_MF_BEPADO_PRODUCT_IMPORT_VENDORID'          => '
+        <p>Der Hersteller bei importierten Artikeln ist immer der Shop bei dem diese aboniert wurden.</p>
+    ',
+    'MF_PRODUCT_IMPORT_PURCHASE_PRICE'                => 'Händlerpreis',
+    'HELP_MF_PRODUCT_IMPORT_PURCHASE_PRICE'           => 'Stelle die Preisgruppe in der Modul-Konfiguration ein.',
+    'MF_BEPADO_PRODUCT_IMPORT_ATTRIBUTES'             => 'Attribute',
+    'MF_PRODUCT_IMPORT_LONG_DESCRIPTION'              => 'Beschreibungstext',
+    'MF_BEPAPO_PRODUCT_IMPORT_CREATE_NEW'             => '<p>Neue Artikel können hier nicht erstellt werden.
+                                                          Sie werden automatisch synchronisiert.<br />Wähle einfach einen aus
+                                                          der Liste oder aboniere Artikel im Bepado Socialnetwork.</p>
+                                                          <p>Artikel können hier auch nicht einfach gelöscht werden, da
+                                                          die Abonierung ebenfalls über das Backend von Bepado erfolgt.</p>',
+    'MF_PRODUCT_EXPORT_TITLE'                         => 'Titel',
+    'HELP_MF_PRODUCT_EXPORT_TITLE'                    => '<p>Titel des exportierten Produkts.</p>
+        <p>Entspricht dem Titel in der Artikelverwaltung des OXID eShop.</p>',
+    'HELP_MF_BEPADO_PRODUCT_EXPORT_SHORTDESCRIPTION'  => '<p>Kurzbeschreibung des exportieren Produkts.</p>
+        <p>Entspricht der Kurzberschreibung in der Artikelverwaltung des OXID eShop.</p>',
+    'HELP_MF_PRODUCT_EXPORT_EAN'                      => '
+        <p> Wird als EAN im Bepado Social network ausgegeben.</p>
+    ',
+    'HELP_MF_BEPADO_PRODUCT_EXPORT_VENDORID'          => '
+        <p>Wähle einen Herrsteller aus oder lasse das Feld frei wenn der eigene Shop als Hersteler im
+        Bepado Socialnetwork angezeigt werden soll.</p>
+    ',
+    'MF_PRODUCT_EXPORT_PURCHASE_PRICE'                => 'Händlerpreis',
+    'HELP_MF_PRODUCT_EXPORT_PURCHASE_PRICE'           => 'Stelle die Preisgruppe in der Modul-Konfiguration ein.',
+    'MF_BEPADO_PRODUCT_EXPORT_ATTRIBUTES'             => 'Attribute',
+    'MF_PRODUCT_EXPORT_LONG_DESCRIPTION'              => 'Beschreibungstext',
+    'HELP_MF_BEPAPO_PRODUCT_EXPORT_CREATE_NEW'        => 'In der Lister erscheinen alle Artikel, die noch nicht für
+        Bepado freigegeben wurden. Vor der Freigabe werden diese konvertiert und validiert um zu überprüfen ob alle
+        nötigen Werte gesetzt sind.',
+    'MF_BEPAPO_PRODUCT_EXPORT_CHOSE_ARTICLE'          => 'Wähle einen Artikel aus',
+    'MF_BEPADO_PRODUCT_TO_EXPORT'                     => 'Artikel',
+    'MF_BEPADO_PRODUCT_EXPORT_SAVE'                   => 'Freigeben',
+    'MF_BEPADO_PRODUCT_EXPORT_DELETE'                 => 'Das Löschen des Eintrages löscht nicht den Artikel sondern
+        hebt dessen Eigenschaft auf ein exportierter Artikel zu sein.',
+    'MF_BEPADE_PRODUCT_VERIFY_ARTICLE'                => 'Bitte passen Sie Ihren Artikel an.',
+
+    'The purchasePrice is not allowed to be 0 or smaller.' => 'Der Artikel enthält keinen Eintrag im Feld Händlerpreis.',
 );

--- a/application/views/admin/tpl/mf_product_export_list.tpl
+++ b/application/views/admin/tpl/mf_product_export_list.tpl
@@ -2,10 +2,10 @@
 [{assign var="where" value=$oView->getListFilter()}]
 
 [{if $readonly}]
-[{assign var="readonly" value="readonly disabled"}]
-[{else}]
-[{assign var="readonly" value=""}]
-[{/if}]
+    [{assign var="readonly" value="readonly disabled"}]
+    [{else}]
+    [{assign var="readonly" value=""}]
+    [{/if}]
 
 <script type="text/javascript">
     <!--
@@ -24,7 +24,83 @@
     <form name="search" id="search" action="[{ $oViewConf->getSelfLink() }]" method="post">
         [{include file="_formparams.tpl" cl="mf_product_export_list" lstrt=$lstrt actedit=$actedit oxid=$oxid fnc="" language=$actlang editlanguage=$actlang}]
         <table cellspacing="0" cellpadding="0" border="0" width="100%">
+            <colgroup>
+                <col width="3%">
+                <col width="45%">
+                <col width="10%">
+                <col width="2%">
+            </colgroup>
+            <tr class="listitem">
+                <td class="listheader first" height="15" width="30" align="center">
+                    [{ oxmultilang ident="GENERAL_ACTIVTITLE" }]
+                </td>
+                <td class="listheader first" height="15" width="30" align="center">
+                    [{oxmultilang ident="MF_BEPADO_ARTICLE_TITLE"}]
+                </td>
+                <td class="listheader first" height="15" width="30" align="center" colspan="2">
+                    <a
+                            href="Javascript:top.oxid.admin.setSorting( document.search, 'mfbepadoproducts', 'shop_id', 'asc');document.search.submit();"
+                            class="listheader">
+                        [{oxmultilang ident="MF_BEPADO_SHOP_ID"}]
+                    </a>
+                </td>
+            </tr>
 
+            [{assign var="blWhite" value=""}]
+            [{assign var="_cnt" value=0}]
+            [{foreach from=$mylist item=listitem}]
+            [{assign var="_cnt" value=$_cnt+1}]
+            <tr id="row.[{$_cnt}]">
+                [{if $listitem->blacklist == 1}]
+                [{assign var="listclass" value=listitem3}]
+                [{else}]
+                [{assign var="listclass" value=listitem$blWhite}]
+                [{/if}]
+                [{if $listitem->mfbepadoproducts__oxid->value == $oxid}]
+                [{assign var="listclass" value=listitem4 }]
+                [{/if}]
+                [{ assign var="oArticle" value=$listitem->getOxArticle() }]
+                <td
+                        valign="top"
+                        class="[{ $listclass}][{ if $oArticle->oxarticles__oxactive->value == 1}] active[{/if}]"
+                        height="15">
+                    <div class="listitemfloating">&nbsp</a></div>
+                </td>
+                <td valign="top" class="[{ $listclass }]">
+                    <div class="listitemfloating">
+                        <a href="Javascript:top.oxid.admin.editThis('[{ $listitem->mfbepadoproducts__oxid->value }]');" class="[{ $listclass}]">[{ $oArticle->oxarticles__oxtitle->value }]</a>
+                    </div>
+                </td>
+                <td valign="top" class="[{ $listclass }]">
+                    <div class="listitemfloating">
+                        <a
+                                href="Javascript:top.oxid.admin.editThis('[{ $listitem->mfbepadoproducts__oxid->value }]');"
+                                class="[{ $listclass}]">
+                            [{assign var="oShop" value=$oView->getShopById($listitem->mfbepadoproducts__shop_id->value)}]
+                            [{ $oShop->name }]
+                        </a>
+                    </div>
+                </td>
+                <td class="[{ $listclass}]">
+                    [{if !$readonly}]
+                    <a
+                            href="Javascript:top.oxid.admin.deleteThis('[{ $listitem->mfbepadoproducts__oxid->value }]');"
+                            class="delete"
+                            id="del.[{$_cnt}]"
+                            title="[{oxmultilang ident="MF_BEPADO_PRODUCT_EXPORT_DELETE"}]"
+                            [{include file="help.tpl" helpid=item_delete}]>
+
+                    </a>
+                    [{/if}]
+                </td>
+            </tr>
+            [{if $blWhite == "2"}]
+            [{assign var="blWhite" value=""}]
+            [{else}]
+            [{assign var="blWhite" value="2"}]
+            [{/if}]
+            [{/foreach}]
+            [{include file="pagenavisnippet.tpl" colspan="5"}]
         </table>
     </form>
 </div>
@@ -35,7 +111,7 @@
     if (parent.parent)
     {   parent.parent.sShopTitle   = "[{$actshopobj->oxshops__oxname->getRawValue()|oxaddslashes}]";
         parent.parent.sMenuItem    = "[{ oxmultilang ident="MF_CONFIGURATION" }]";
-        parent.parent.sMenuSubItem = "[{ oxmultilang ident="MF_PRODUCT_EXPORT_LIST_MENUSUBITEM" }]";
+        parent.parent.sMenuSubItem = "[{ oxmultilang ident="MF_PRODUCT_IMPORT_LIST_MENUSUBITEM" }]";
         parent.parent.sWorkArea    = "[{$_act}]";
         parent.parent.setTitle();
     }

--- a/application/views/admin/tpl/mf_product_export_main.tpl
+++ b/application/views/admin/tpl/mf_product_export_main.tpl
@@ -1,10 +1,36 @@
 [{include file="headitem.tpl" title="GENERAL_ADMIN_TITLE"|oxmultilangassign}]
 
+<script type="text/javascript">
+    function editThis( sID )
+    {
+        var oTransfer = top.basefrm.edit.document.getElementById( "transfer" );
+        oTransfer.oxid.value = sID;
+        oTransfer.cl.value = top.basefrm.list.sDefClass;
+
+        //forcing edit frame to reload after submit
+        top.forceReloadingEditFrame();
+
+        var oSearch = top.basefrm.list.document.getElementById( "search" );
+        oSearch.oxid.value = sID;
+        oSearch.actedit.value = 0;
+        oSearch.submit();
+    }
+    window.onload = function ()
+    {
+        [{ if $updatelist == 1}]
+        top.oxid.admin.updateList('[{ $oxid }]');
+        [{ /if}]
+        var oField = top.oxid.admin.getLockTarget();
+        oField.onchange = oField.onkeyup = oField.onmouseout = top.oxid.admin.unlockSave;
+    }
+</script>
+
+
 [{if $readonly}]
-[{assign var="readonly" value="readonly disabled"}]
-[{else}]
-[{assign var="readonly" value=""}]
-[{/if}]
+    [{assign var="readonly" value="readonly disabled"}]
+    [{else}]
+    [{assign var="readonly" value=""}]
+    [{/if}]
 
 
 <form name="transfer" id="transfer" action="[{ $oViewConf->getSelfLink() }]" method="post">
@@ -14,23 +40,353 @@
     <input type="hidden" name="editlanguage" value="[{ $editlanguage }]">
 </form>
 
-<form name="myedit" id="myedit" action="[{ $oViewConf->getSelfLink() }]" method="post">
-    [{ $oViewConf->getHiddenSid() }]
-    <input type="hidden" name="cl" value="mf_product_export_main">
-    <input type="hidden" name="fnc" value="">
-    <input type="hidden" name="oxid" value="[{ $oxid }]">
-    <input type="hidden" name="editval[oxid]" value="[{ $oxid }]">
+<table cellspacing="0" cellpadding="0" border="0" style="width:98%;">
+    <form
+            name="myedit"
+            id="myedit"
+            action="[{ $oViewConf->getSelfLink() }]"
+            method="post"
+            onSubmit="return copyLongDesc( 'oxarticles__oxlongdesc' );"
+            style="padding: 0px;margin: 0px;height:0px;" style="padding: 0px;margin: 0px;height:0px;">
+        [{$oViewConf->getHiddenSid()}]
+        <input type="hidden" name="cl" value="mf_product_export_main">
+        <input type="hidden" name="fnc" value="">
+        <input type="hidden" name="oxid" value="[{ $oxid }]">
+        <input type="hidden" name="editval[oxarticles__oxid]" value="[{ $oxid }]">
+        <input type="hidden" name="editval[oxarticles__oxlongdesc]" value="">
 
-    <table cellspacing="0" cellpadding="0" border="0" width="98%">
+        <tr height="10"><td></td><td></td></tr>
+
+        [{if $oxid != -1}]
+        [{assign var="oArticle" value=$edit->oxArticle}]
+        [{assign var="oProduct" value=$edit->mfBepadoProduct}]
         <tr>
+            <td width="15"></td>
             <td valign="top" class="edittext">
+                <table cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td colspan="2">
+                            [{if $errorsavingatricle eq 1}]
+                            <div class="errorbox">[{ oxmultilang ident=$errorMessage }]</div>
+                            [{/if}]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext" width="120">
+                            [{ oxmultilang ident="ARTICLE_MAIN_ACTIVE" }]
+                        </td>
+                        <td class="edittext">
+                            <input type="hidden" name="editval[oxArticle][oxarticles__oxactive]" value="0">
+                            <input
+                                    class="edittext"
+                                    type="checkbox"
+                                    name="editval[oxArticle][oxarticles__oxactive]"
+                                    value='1'
+                                    [{if $oArticle->oxarticles__oxactive->value == 1}]checked[{/if}]
+                                    [{ $readonly }]>
+                            [{ oxinputhelp ident="HELP_ARTICLE_MAIN_ACTIVE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="MF_PRODUCT_EXPORT_TITLE" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32"
+                                    maxlength="[{$oArticle->oxarticles__oxtitle->fldmax_length}]"
+                                    id="oLockTarget"
+                                    name="editval[oxArticle][oxarticles__oxtitle]"
+                                    value="[{$oArticle->oxarticles__oxtitle->value}]"
+                                    [{ $readonly }] />
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_EXPORT_TITLE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_EAN" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32" maxlength="[{$oArticle__oxean->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxean]"
+                                    value="[{$oArticle->oxarticles__oxean->value}]"
+                                    [{ $readonly }]
+                                    >
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_EXPORT_EAN" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_SHORTDESC" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32"
+                                    maxlength="[{$oArticle->oxarticles__oxshortdesc->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxshortdesc]"
+                                    value="[{$oArticle->oxarticles__oxshortdesc->value}]"
+                                    [{ $readonly }]>
+                            [{ oxinputhelp ident="HELP_MF_BEPADO_PRODUCT_EXPORT_SHORTDESCRIPTION" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_VENDORID" }]
+                        </td>
+                        <td class="edittext">
+                            <select class="editinput" name="editval[oxArticle][oxarticles__oxvendorid]" [{ $readonly }]>
+                                <option value="" selected>---</option>
+                                [{foreach from=$oView->getVendorList() item=oVendor}]
+                                <option value="[{$oVendor->oxvendor__oxid->value}]"[{if $oArticle->oxarticles__oxvendorid->value == $oVendor->oxvendor__oxid->value}] selected[{/if}]>[{ $oVendor->oxvendor__oxtitle->value }]</option>
+                                [{/foreach}]
+                            </select>
+                            [{ oxinputhelp ident="HELP_MF_BEPADO_PRODUCT_EXPORT_VENDORID" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_PRICE" }] ([{ $oActCur->sign }])
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="8"
+                                    maxlength="[{$oArticle->oxarticles__oxprice->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxprice]"
+                                    value="[{$oArticle->oxarticles__oxprice->value}]"
+                                    [{ $readonly }] />
+                            [{assign var="oPrice" value=$oArticle->getPrice()}]
+                            &nbsp;<em>( [{$oPrice->getBruttoPrice()}] )</em>
+                            [{ oxinputhelp ident="HELP_ARTICLE_MAIN_PRICE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        [{assign var="purchasePriceField" value=$edit->oArticleHelper->getPurchasePriceField()}]
+                        <td class="edittext">
+                            [{ oxmultilang ident="MF_PRODUCT_EXPORT_PURCHASE_PRICE" }] ([{ $oActCur->sign }])
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="8"
+                                    maxlength="[{$oArticle->$purchasePriceField->fldmax_length}]"
+                                    name="editval[oxArticle][[{$purchasePriceField}]]"
+                                    value="[{$oArticle->$purchasePriceField->value}]"
+                                    [{ $readonly }]>
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_EXPORT_PURCHASE_PRICE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_STOCK_DELIVERY" }]
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="20"
+                                    maxlength="[{$oArticle->oxarticles__oxdelivery->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxdelivery]"
+                                    value="[{$oArticle->oxarticles__oxdelivery|oxformdate}]"
+                                    [{include file="help.tpl" helpid=article_delivery}]
+                                    [{ $readonly }]>
+                            [{ oxinputhelp ident="HELP_ARTICLE_STOCK_DELIVERY" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext" colspan="2"><br><br>
+                            <input
+                                    type="submit"
+                                    class="edittext"
+                                    id="oLockButton"
+                                    name="saveArticle"
+                                    value="[{ oxmultilang ident="ARTICLE_MAIN_SAVE" }]"
+                            onClick="Javascript:document.myedit.fnc.value='save'"
+                            [{if !$oArticle->oxarticles__oxtitle->value && !$oxparentid }]disabled[{/if}]
+                            [{ $readonly }]
+                            >
+                        </td>
+                    </tr>
+                </table>
             </td>
             <!-- Anfang rechte Seite -->
-            <td valign="top" class="edittext" align="left" width="50%">
+            <td valign="top" class="edittext" align="left" style="table-layout:fixed">
+                <fieldset
+                        title="[{ oxmultilang ident="MF_BEPADO_PRODUCT_EXPORT_ATTRIBUTES" }]"
+                style="padding-left: 5px;">
+                <legend>[{ oxmultilang ident="MF_BEPADO_PRODUCT_EXPORT_ATTRIBUTES" }]</legend><br>
+
+                <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_EXTEND_WEIGHT" }]
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="10"
+                                    maxlength="[{$oArticle->oxarticles__oxweight->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxweight]"
+                                    value="[{$oArticle->oxarticles__oxweight->value}]"
+                                    [{ $readonly }]
+                                    >
+                            [{oxmultilang ident="ARTICLE_EXTEND_WEIGHT_UNIT"}]
+                            [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_WEIGHT" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_EXTEND_MASS" }]
+                        </td>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_EXTEND_LENGTH" }]&nbsp;
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="3"
+                                    maxlength="[{$oArticle->oxarticles__oxlength->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxlength]"
+                                    value="[{$oArticle->oxarticles__oxlength->value}]"
+                                    [{ $readonly }]>
+                            [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                            [{ oxmultilang ident="ARTICLE_EXTEND_WIDTH" }]&nbsp;
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="3"
+                                    maxlength="[{$oArticle->oxarticles__oxlength->fldmax_width}]"
+                                    name="editval[oxArticle][oxarticles__oxwidth]"
+                                    value="[{$oArticle->oxarticles__oxwidth->value}]"
+                                    [{ $readonly }]>
+                            [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                            [{ oxmultilang ident="ARTICLE_EXTEND_HEIGHT" }]&nbsp;
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="3"
+                                    maxlength="[{$oArticle->oxarticles__oxlength->fldmax_height}]"
+                                    name="editval[oxArticle][oxarticles__oxheight]"
+                                    value="[{$oArticle->oxarticles__oxheight->value}]"
+                                    [{ $readonly }]>
+                            [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                            [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_MASS" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_EXTEND_UNITQUANTITY" }]
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="10"
+                                    maxlength="[{$oArticle->oxarticles__oxunitquantity->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxunitquantity]"
+                                    value="[{$oArticle->oxarticles__oxunitquantity->value}]"
+                                    [{ $readonly }]>
+                            &nbsp;&nbsp;&nbsp;&nbsp; [{ oxmultilang ident="ARTICLE_EXTEND_UNITNAME" }]:
+                            [{if $oView->getUnitsArray()}]
+                            <select name="editval[oxArticle][oxarticles__oxunitname]" onChange="JavaScript:processUnitInput( this, 'unitinput' )">
+                                <option value="">-</option>
+                                [{foreach from=$oView->getUnitsArray() key=sKey item=sUnit}]
+                                [{assign var="sUnitSelected" value=""}]
+                                [{if $oArticle->oxarticles__oxunitname->value == $sKey}]
+                                [{assign var="blUseSelection" value=true}]
+                                [{assign var="sUnitSelected" value="selected"}]
+                                [{/if}]
+                                <option value="[{$sKey}]" [{$sUnitSelected}]>[{$sUnit}]</option>
+                                [{/foreach}]
+                            </select> /
+                            [{/if}]
+                            <input
+                                    type="text"
+                                    id="unitinput"
+                                    class="editinput"
+                                    size="10"
+                                    maxlength="[{$oArticle->oxarticles__oxunitname->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxunitname]"
+                                    value="[{if !$blUseSelection}][{$oArticle->oxarticles__oxunitname->value}][{/if}]"
+                                    [{if $blUseSelection}]disabled="true"[{/if}] [{include file="help.tpl" helpid=article_unit}]>
+                            [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_UNITQUANTITY" }]
+                        </td>
+                    </tr>
+                </table>
+
+                </fieldset>
+
+                <fieldset
+                        title="[{ oxmultilang ident="MF_PRODUCT_EXPORT_LONG_DESCRIPTION" }]"
+                style="padding-left: 5px;">
+                <legend>[{ oxmultilang ident="MF_PRODUCT_EXPORT_LONG_DESCRIPTION" }]</legend>
+                [{ $editor }]
+                </fieldset>
             </td>
         </tr>
-    </table>
-</form>
+        [{/if}]
+
+        [{if $oxid == -1}]
+
+        <input type="hidden" name="editval[export_to_bepado]" value="1">
+
+        <tr>
+            <td width="15"></td>
+            <td valign="top" class="edittext">
+                <table cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td colspan="2">
+                            [{if $errorExportingArticle eq 1}]
+                            <div class="errorbox">
+                                <p>[{ oxmultilang ident=$errorMessage }]</p>
+                                <p>[{ oxmultilang ident="MF_BEPADE_PRODUCT_VERIFY_ARTICLE" }]</p>
+                            </div>
+                            [{/if}]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="MF_BEPADO_PRODUCT_TO_EXPORT" }]
+                        </td>
+                        <td class="edittext">
+                            <select class="editinput" name="editval[articleToExport]" [{ $readonly }]>
+                                <option value="" selected>[{ oxmultilang ident="MF_BEPAPO_PRODUCT_EXPORT_CHOSE_ARTICLE" }]</option>
+                                [{foreach from=$oView->getArticlesToExport() item=listItem}]
+                                <option value="[{$listItem->oxarticles__oxid->value}]">
+                                    [{ $listItem->pwrsearchval|oxtruncate:200:"..":false }]</option>
+                                [{/foreach}]
+                            </select>
+                            [{ oxinputhelp ident="HELP_MF_BEPAPO_PRODUCT_EXPORT_CREATE_NEW" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext" colspan="2"><br><br>
+                            <input
+                                    type="submit"
+                                    class="edittext"
+                                    id="oLockButton"
+                                    name="saveArticle"
+                                    value="[{ oxmultilang ident="MF_BEPADO_PRODUCT_EXPORT_SAVE" }]"
+                            onClick="Javascript:document.myedit.fnc.value='save'"
+                            [{ $readonly }]
+                            >
+                        </td>
+                    </tr>
+                </table>
+            <td></td>
+        </tr>
+        [{/if}]
+    </form>
+</table>
 
 [{include file="bottomnaviitem.tpl"}]
 

--- a/application/views/admin/tpl/mf_product_import_list.tpl
+++ b/application/views/admin/tpl/mf_product_import_list.tpl
@@ -24,7 +24,84 @@
     <form name="search" id="search" action="[{ $oViewConf->getSelfLink() }]" method="post">
         [{include file="_formparams.tpl" cl="mf_product_import_list" lstrt=$lstrt actedit=$actedit oxid=$oxid fnc="" language=$actlang editlanguage=$actlang}]
         <table cellspacing="0" cellpadding="0" border="0" width="100%">
+            <colgroup>
+                <col width="3%">
+                <col width="45%">
+                <col width="10%">
+                <col width="10%">
+                <col width="2%">
+            </colgroup>
+            <tr class="listitem">
+                <td class="listheader first" height="15" width="30" align="center">
+                    [{ oxmultilang ident="GENERAL_ACTIVTITLE" }]
+                </td>
+                <td class="listheader first" height="15" width="30" align="center">
+                    [{oxmultilang ident="MF_BEPADO_ARTICLE_TITLE"}]
+                </td>
+                <td class="listheader first" height="15" width="30" align="center">
+                    <a
+                            href="Javascript:top.oxid.admin.setSorting( document.search, 'mfbepadoproducts', 'p_source_id', 'asc');document.search.submit();"
+                            class="listheader">
+                        [{oxmultilang ident="MF_BEPADO_PRODUCT_SOURCE_ID"}]
+                    </a>
+                </td>
+                <td class="listheader first" height="15" width="30" align="center">
+                    <a
+                            href="Javascript:top.oxid.admin.setSorting( document.search, 'mfbepadoproducts', 'shop_id', 'asc');document.search.submit();"
+                            class="listheader">
+                        [{oxmultilang ident="MF_BEPADO_SHOP_ID"}]
+                    </a>
+                </td>
+            </tr>
 
+            [{assign var="blWhite" value=""}]
+            [{assign var="_cnt" value=0}]
+            [{foreach from=$mylist item=listitem}]
+            [{assign var="_cnt" value=$_cnt+1}]
+            <tr id="row.[{$_cnt}]">
+                [{if $listitem->blacklist == 1}]
+                [{assign var="listclass" value=listitem3}]
+                [{else}]
+                [{assign var="listclass" value=listitem$blWhite}]
+                [{/if}]
+                [{if $listitem->mfbepadoproducts__oxid->value == $oxid}]
+                [{assign var="listclass" value=listitem4 }]
+                [{/if}]
+                [{ assign var="oArticle" value=$listitem->getOxArticle() }]
+                <td
+                        valign="top"
+                        class="[{ $listclass}][{ if $oArticle->oxarticles__oxactive->value == 1}] active[{/if}]"
+                        height="15">
+                    <div class="listitemfloating">&nbsp</a></div>
+                </td>
+                <td valign="top" class="[{ $listclass }]">
+                    <div class="listitemfloating">
+                        <a href="Javascript:top.oxid.admin.editThis('[{ $listitem->mfbepadoproducts__oxid->value }]');" class="[{ $listclass}]">[{ $oArticle->oxarticles__oxtitle->value }]</a>
+                    </div>
+                </td>
+                <td valign="top" class="[{ $listclass }]">
+                    <div class="listitemfloating">
+                        <a
+                                href="Javascript:top.oxid.admin.editThis('[{ $listitem->mfbepadoproducts__oxid->value }]');"
+                                class="[{ $listclass}]">
+                            [{assign var="oShop" value=$oView->getShopById($listitem->mfbepadoproducts__shop_id->value)}]
+                            [{ $oShop->name }]
+                        </a>
+                    </div>
+                </td>
+                <td valign="top" class="[{ $listclass }]">
+                    <div class="listitemfloating">
+                        <a href="Javascript:top.oxid.admin.editThis('[{ $listitem->mfbepadoproducts__oxid->value }]');" class="[{ $listclass}]">[{ $listitem->mfbepadoproducts__shop_id->value }]</a>
+                    </div>
+                </td>
+            </tr>
+            [{if $blWhite == "2"}]
+            [{assign var="blWhite" value=""}]
+            [{else}]
+            [{assign var="blWhite" value="2"}]
+            [{/if}]
+            [{/foreach}]
+            [{include file="pagenavisnippet.tpl" colspan="5"}]
         </table>
     </form>
 </div>

--- a/application/views/admin/tpl/mf_product_import_main.tpl
+++ b/application/views/admin/tpl/mf_product_import_main.tpl
@@ -14,23 +14,317 @@
     <input type="hidden" name="editlanguage" value="[{ $editlanguage }]">
 </form>
 
-<form name="myedit" id="myedit" action="[{ $oViewConf->getSelfLink() }]" method="post">
-    [{ $oViewConf->getHiddenSid() }]
-    <input type="hidden" name="cl" value="mf_product_import_main">
-    <input type="hidden" name="fnc" value="">
-    <input type="hidden" name="oxid" value="[{ $oxid }]">
-    <input type="hidden" name="editval[oxid]" value="[{ $oxid }]">
+<table cellspacing="0" cellpadding="0" border="0" style="width:98%;">
+    <form
+            name="myedit"
+            id="myedit"
+            action="[{ $oViewConf->getSelfLink() }]"
+            method="post"
+            onSubmit="return copyLongDesc( 'oxarticles__oxlongdesc' );"
+            style="padding: 0px;margin: 0px;height:0px;" style="padding: 0px;margin: 0px;height:0px;">
+        [{$oViewConf->getHiddenSid()}]
+        <input type="hidden" name="cl" value="mf_product_import_main">
+        <input type="hidden" name="fnc" value="">
+        <input type="hidden" name="oxid" value="[{ $oxid }]">
+        <input type="hidden" name="editval[oxarticles__oxid]" value="[{ $oxid }]">
+        <input type="hidden" name="editval[oxarticles__oxlongdesc]" value="">
 
-    <table cellspacing="0" cellpadding="0" border="0" width="98%">
+        <tr height="10"><td></td><td></td></tr>
+
+        [{if $oxid != -1}]
+        [{assign var="oArticle" value=$edit->oxArticle}]
+        [{assign var="oProduct" value=$edit->mfBepadoProduct}]
         <tr>
+            <td width="15"></td>
             <td valign="top" class="edittext">
+                <table cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td colspan="2">
+                            [{ if $errorsavingatricle eq 1 }]
+                            <div class="errorbox">[{ oxmultilang ident="ARTICLE_MAIN_ERRORSAVINGARTICLE" }]</div>
+                            [{/if}]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext" width="120">
+                            [{ oxmultilang ident="ARTICLE_MAIN_ACTIVE" }]
+                        </td>
+                        <td class="edittext">
+                            <input type="hidden" name="editval[oxArticle][oxarticles__oxactive]" value="0">
+                            <input
+                                    class="edittext"
+                                    type="checkbox"
+                                    name="editval[oxArticle][oxarticles__oxactive]"
+                                    value='1'
+                                    [{if $oArticle->oxarticles__oxactive->value == 1}]checked[{/if}]
+                                    [{ $readonly }]>
+                            [{ oxinputhelp ident="HELP_ARTICLE_MAIN_ACTIVE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="MF_PRODUCT_IMPORT_TITLE" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32"
+                                    maxlength="[{$oArticle->oxarticles__oxtitle->fldmax_length}]"
+                                    id="oLockTarget"
+                                    name="editval[oxArticle][oxarticles__oxtitle]"
+                                    value="[{$oArticle->oxarticles__oxtitle->value}]"
+                                    readonly />
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_IMPORT_TITLE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_EAN" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32" maxlength="[{$oArticle__oxean->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxean]"
+                                    value="[{$oArticle->oxarticles__oxean->value}]"
+                                    readonly
+                                    >
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_IMPORT_EAN" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_SHORTDESC" }]&nbsp;
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="32"
+                                    maxlength="[{$oArticle->oxarticles__oxshortdesc->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxshortdesc]"
+                                    value="[{$oArticle->oxarticles__oxshortdesc->value}]"
+                                    readonly>
+                            [{ oxinputhelp ident="HELP_MF_BEPADO_PRODUCT_IMPORT_SHORTDESCRIPTION" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_VENDORID" }]
+                        </td>
+                        <td class="edittext">
+                            <select class="editinput" name="editval[oxArticle][oxarticles__oxvendorid]" readonly>
+                                <option value="" selected>---</option>
+                                [{foreach from=$oView->getVendorList() item=oVendor}]
+                                <option value="[{$oVendor->oxvendor__oxid->value}]"[{if $oArticle->oxarticles__oxvendorid->value == $oVendor->oxvendor__oxid->value}] selected[{/if}]>[{ $oVendor->oxvendor__oxtitle->value }]</option>
+                                [{/foreach}]
+                            </select>
+                            [{ oxinputhelp ident="HELP_MF_BEPADO_PRODUCT_IMPORT_VENDORID" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_MAIN_PRICE" }] ([{ $oActCur->sign }])
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="8"
+                                    maxlength="[{$oArticle->oxarticles__oxprice->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxprice]"
+                                    value="[{$oArticle->oxarticles__oxprice->value}]"
+                                    readonly />
+                            [{assign var="oPrice" value=$oArticle->getPrice()}]
+                            &nbsp;<em>( [{$oPrice->getBruttoPrice()}] )</em>
+                            [{ oxinputhelp ident="HELP_ARTICLE_MAIN_PRICE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        [{assign var="purchasePriceField" value=$edit->oArticleHelper->getPurchasePriceField()}]
+                        <td class="edittext">
+                            [{ oxmultilang ident="MF_PRODUCT_IMPORT_PURCHASE_PRICE" }] ([{ $oActCur->sign }])
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="8"
+                                    maxlength="[{$oArticle->$purchasePriceField->fldmax_length}]"
+                                    name="editval[oxArticle][[{$purchasePriceField}]]"
+                                    value="[{$oArticle->$purchasePriceField->value}]"
+                                    readonly>
+                            [{ oxinputhelp ident="HELP_MF_PRODUCT_IMPORT_PURCHASE_PRICE" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext">
+                            [{ oxmultilang ident="ARTICLE_STOCK_DELIVERY" }]
+                        </td>
+                        <td class="edittext">
+                            <input
+                                    type="text"
+                                    class="editinput"
+                                    size="20"
+                                    maxlength="[{$oArticle->oxarticles__oxdelivery->fldmax_length}]"
+                                    name="editval[oxArticle][oxarticles__oxdelivery]"
+                                    value="[{$oArticle->oxarticles__oxdelivery|oxformdate}]"
+                                    [{include file="help.tpl" helpid=article_delivery}]
+                                    readonly>
+                            [{ oxinputhelp ident="HELP_ARTICLE_STOCK_DELIVERY" }]
+                        </td>
+                    </tr>
+                    <tr>
+                        <td class="edittext" colspan="2"><br><br>
+                            <input
+                                    type="submit"
+                                    class="edittext"
+                                    id="oLockButton"
+                                    name="saveArticle"
+                                    value="[{ oxmultilang ident="ARTICLE_MAIN_SAVE" }]"
+                                    onClick="Javascript:document.myedit.fnc.value='save'"
+                                    [{ if !$oArticle->oxarticles__oxtitle->value && !$oxparentid }]disabled[{/if}]
+                                    [{ $readonly }]
+                                    >
+                        </td>
+                    </tr>
+                </table>
             </td>
             <!-- Anfang rechte Seite -->
-            <td valign="top" class="edittext" align="left" width="50%">
+            <td valign="top" class="edittext" align="left" style="table-layout:fixed">
+                <fieldset
+                        title="[{ oxmultilang ident="MF_BEPADO_PRODUCT_IMPORT_ATTRIBUTES" }]"
+                style="padding-left: 5px;">
+                    <legend>[{ oxmultilang ident="MF_BEPADO_PRODUCT_IMPORT_ATTRIBUTES" }]</legend><br>
+
+                    <table cellspacing="0" cellpadding="0" border="0" width="100%">
+                        <tr>
+                            <td class="edittext">
+                                [{ oxmultilang ident="ARTICLE_EXTEND_WEIGHT" }]
+                            </td>
+                            <td class="edittext">
+                                <input
+                                        type="text"
+                                        class="editinput"
+                                        size="10"
+                                        maxlength="[{$oArticle->oxarticles__oxweight->fldmax_length}]"
+                                        name="editval[oxArticle][oxarticles__oxweight]"
+                                        value="[{$oArticle->oxarticles__oxweight->value}]"
+                                        readonly
+                                        >
+                                [{oxmultilang ident="ARTICLE_EXTEND_WEIGHT_UNIT"}]
+                                [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_WEIGHT" }]
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="edittext">
+                                [{ oxmultilang ident="ARTICLE_EXTEND_MASS" }]
+                            </td>
+                            <td class="edittext">
+                                [{ oxmultilang ident="ARTICLE_EXTEND_LENGTH" }]&nbsp;
+                                <input
+                                        type="text"
+                                        class="editinput"
+                                        size="3"
+                                        maxlength="[{$oArticle->oxarticles__oxlength->fldmax_length}]"
+                                        name="editval[oxArticle][oxarticles__oxlength]"
+                                        value="[{$oArticle->oxarticles__oxlength->value}]"
+                                        readonly>
+                                [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                                [{ oxmultilang ident="ARTICLE_EXTEND_WIDTH" }]&nbsp;
+                                <input
+                                        type="text"
+                                        class="editinput"
+                                        size="3"
+                                        maxlength="[{$oArticle->oxarticles__oxlength->fldmax_width}]"
+                                        name="editval[oxArticle][oxarticles__oxwidth]"
+                                        value="[{$oArticle->oxarticles__oxwidth->value}]"
+                                        readonly>
+                                [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                                [{ oxmultilang ident="ARTICLE_EXTEND_HEIGHT" }]&nbsp;
+                                <input
+                                        type="text"
+                                        class="editinput"
+                                        size="3"
+                                        maxlength="[{$oArticle->oxarticles__oxlength->fldmax_height}]"
+                                        name="editval[oxArticle][oxarticles__oxheight]"
+                                        value="[{$oArticle->oxarticles__oxheight->value}]"
+                                        readonly>
+                                [{oxmultilang ident="ARTICLE_EXTEND_DIMENSIONS_UNIT"}]
+                                [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_MASS" }]
+                            </td>
+                        </tr>
+                        <tr>
+                            <td class="edittext">
+                                [{ oxmultilang ident="ARTICLE_EXTEND_UNITQUANTITY" }]
+                            </td>
+                            <td class="edittext">
+                                <input
+                                        type="text"
+                                        class="editinput"
+                                        size="10"
+                                        maxlength="[{$oArticle->oxarticles__oxunitquantity->fldmax_length}]"
+                                        name="editval[oxArticle][oxarticles__oxunitquantity]"
+                                        value="[{$oArticle->oxarticles__oxunitquantity->value}]"
+                                        readonly>
+                                &nbsp;&nbsp;&nbsp;&nbsp; [{ oxmultilang ident="ARTICLE_EXTEND_UNITNAME" }]:
+                                [{if $oView->getUnitsArray()}]
+                                <select name="editval[oxArticle][oxarticles__oxunitname]" onChange="JavaScript:processUnitInput( this, 'unitinput' )">
+                                    <option value="">-</option>
+                                    [{foreach from=$oView->getUnitsArray() key=sKey item=sUnit}]
+                                    [{assign var="sUnitSelected" value=""}]
+                                    [{if $oArticle->oxarticles__oxunitname->value == $sKey}]
+                                    [{assign var="blUseSelection" value=true}]
+                                    [{assign var="sUnitSelected" value="selected"}]
+                                    [{/if}]
+                                    <option value="[{$sKey}]" [{$sUnitSelected}]>[{$sUnit}]</option>
+                                    [{/foreach}]
+                                </select> /
+                                [{/if}]
+                                <input
+                                        type="text"
+                                        id="unitinput"
+                                        class="editinput"
+                                        size="10"
+                                        maxlength="[{$oArticle->oxarticles__oxunitname->fldmax_length}]"
+                                        name="editval[oxArticle][oxarticles__oxunitname]"
+                                        value="[{if !$blUseSelection}][{$oArticle->oxarticles__oxunitname->value}][{/if}]"
+                                        [{if $blUseSelection}]disabled="true"[{/if}] [{include file="help.tpl" helpid=article_unit}]>
+                                [{ oxinputhelp ident="HELP_ARTICLE_EXTEND_UNITQUANTITY" }]
+                            </td>
+                        </tr>
+                    </table>
+
+                </fieldset>
+
+                <fieldset
+                        title="[{ oxmultilang ident="MF_PRODUCT_IMPORT_LONG_DESCRIPTION" }]"
+                        style="padding-left: 5px;">
+                    <legend>[{ oxmultilang ident="MF_PRODUCT_IMPORT_LONG_DESCRIPTION" }]</legend>
+                    [{ $editor }]
+                </fieldset>
             </td>
+</tr>
+        [{/if}]
+
+        [{if $oxid == -1}]
+        <tr>
+            <td width="15"></td>
+            <td valign="top" class="edittext">
+                <table cellspacing="0" cellpadding="0" border="0">
+                    <tr>
+                        <td colspan="2">
+                            [{ oxmultilang ident="MF_BEPAPO_PRODUCT_IMPORT_CREATE_NEW" }]
+                        </td>
+                    </tr>
+                </table>
+            <td></td>
         </tr>
-    </table>
-</form>
+        [{/if}]
+    </form>
+</table>
 
 [{include file="bottomnaviitem.tpl"}]
 

--- a/metadata.php
+++ b/metadata.php
@@ -55,6 +55,7 @@ $aModule = array(
         'mfunit'          => $aPaths['controllers'] . '/admin/mfunit.php',
         'mfunit_main'     => $aPaths['controllers'] . '/admin/mfunit_main.php',
         'mfunit_list'     => $aPaths['controllers'] . '/admin/mfunit_list.php',
+        'mf_product_admin_list'          => $aPaths['controllers'] . '/admin/mf_product_admin_list.php',
         'mf_product_import'              => $aPaths['controllers'] . '/admin/mf_product_import.php',
         'mf_product_import_main'         => $aPaths['controllers'] . '/admin/mf_product_import_main.php',
         'mf_product_import_list'         => $aPaths['controllers'] . '/admin/mf_product_import_list.php',
@@ -66,6 +67,7 @@ $aModule = array(
         'oxidProductToShop'     => $aPaths['models'] . '/productToShop.php',
         'mfBepadoConfiguration' => $aPaths['models'] . '/mfBepadoConfiguration.php',
         'mfBepadoUnit'          => $aPaths['models'] . '/mfBepadoUnit.php',
+        'mfBepadoProduct'       => $aPaths['models'] . '/mfBepadoProduct.php',
 
         'mf_converter_interface'   => $aPaths['converter'] . '/mf_converter_interface.php',
         'mf_abstract_converter'    => $aPaths['converter'] . '/mf_abstract_converter.php',
@@ -157,5 +159,3 @@ $aModule = array(
         'onActivate'   => 'EventListener::onActivate',
     ),
 );
-
-

--- a/tests/unit/controller/admin/mf_product_admin_listTest.php
+++ b/tests/unit/controller/admin/mf_product_admin_listTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Bepado\SDK\Struct\Shop;
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+abstract class mf_product_admin_listTest extends BaseTestCase
+{
+    /**
+     * @var mf_product_admin_list
+     */
+    protected $oView;
+
+    protected $mfSdkHelper;
+    protected $sdk;
+    protected $oxArticle;
+
+    public function setUp()
+    {
+        parent::setUp();
+        parent::prepareVersionLayerWithConfig();
+
+        $this->mfSdkHelper = $this->getMockBuilder('mf_sdk_helper')->disableOriginalConstructor()->getMock();
+        $this->sdk = $this->getMockBuilder('sdkMock')->disableOriginalConstructor()->getMock();
+        $this->mfSdkHelper
+            ->expects($this->any())
+            ->method('instantiateSdk')
+            ->will($this->returnValue($this->sdk));
+        $this->oxArticle = $this->getMockBuilder('oxArticle')->disableOriginalConstructor()->getMock();
+    }
+
+    public function testGetShopById()
+    {
+        $expectedShop = new Shop();
+        $expectedShop->id = 'some-id';
+        $expectedShop->name = 'some-name';
+        $expectedShop->url = 'http://www.some-shop.de';
+
+        $this->sdk
+            ->expects($this->once())
+            ->method('getShop')
+            ->with($this->equalTo('some-id'))
+            ->will($this->returnValue($expectedShop));
+
+        $actualShop = $this->oView->getShopById('some-id');
+
+        $this->assertEquals($expectedShop, $actualShop);
+    }
+
+    public function testGetShopByIdWontAskTwice()
+    {
+
+        $expectedShop = new Shop();
+        $expectedShop->id = 'some-id';
+        $expectedShop->name = 'some-name';
+        $expectedShop->url = 'http://www.some-shop.de';
+
+        $this->sdk
+            ->expects($this->once())
+            ->method('getShop')
+            ->with($this->equalTo('some-id'))
+            ->will($this->returnValue($expectedShop));
+
+        $this->oView->getShopById('some-id');
+        $this->oView->getShopById('some-id');
+    }
+
+    public function testGetShopByIdReplacesNullByUnknown()
+    {
+        $givenShop = new Shop();
+        $givenShop->id = 'some-id';
+        $givenShop->name = null;
+        $givenShop->url = 'http://www.some-shop.de';
+
+        $this->sdk
+            ->expects($this->once())
+            ->method('getShop')
+            ->with($this->equalTo('some-id'))
+            ->will($this->returnValue($givenShop));
+        $expectedShop = clone $givenShop;
+        $expectedShop->name = 'Unknown';
+
+        $actualShop = $this->oView->getShopById('some-id');
+        $this->assertEquals($expectedShop, $actualShop);
+    }
+
+    public function testRenderWithFilterForState()
+    {
+        $oMfBepadoProductExported = new mfBepadoProduct();
+        $oMfBepadoProductExported->setState(mfBepadoProduct::PRODUCT_STATE_EXPORTED);
+        $oMfBepadoProductExported->setProductSourceId('exported-id');
+
+        $oMfBepadoProductImported = new mfBepadoProduct();
+        $oMfBepadoProductImported->setState(mfBepadoProduct::PRODUCT_STATE_IMPORTED);
+        $oMfBepadoProductImported->setProductSourceId('imported-id');
+
+        $oList = new oxList();
+        $oList->offsetSet("1", $oMfBepadoProductExported);
+        $oList->offsetSet("2", $oMfBepadoProductImported);
+
+        $sClassName = mfBepadoProduct::PRODUCT_STATE_EXPORTED === $this->getState() ? 'mf_product_export_list' : 'mf_product_import_list';
+
+        $oView = $this->getMock($sClassName, array("getItemList"));
+        $oView->expects($this->any())->method('getItemList')->will($this->returnValue($oList));
+        $oView->render();
+        $aViewData = $oView->getViewData();
+
+        $myList = $aViewData['mylist']->getArray();
+        $this->assertCount(1, $myList, 'There should be one item only in the list after the filter.');
+        $actualItem = array_shift($myList);
+        $expectedId = mfBepadoProduct::PRODUCT_STATE_EXPORTED === $this->getState() ? 'exported-id' : 'imported-id';
+        $this->assertEquals($expectedId, $actualItem->getProductSourceId());
+    }
+
+    /**
+     * For the filter test on render() method.
+     *
+     * @return string
+     */
+    abstract protected function getState();
+
+    protected function getObjectMapping()
+    {
+        return array(
+            'mf_sdk_helper'         => $this->mfSdkHelper,
+            'sdk'                   => $this->sdk,
+            'oxArticle'             => $this->oxArticle
+        );
+    }
+}

--- a/tests/unit/controller/admin/mf_product_export_listTest.php
+++ b/tests/unit/controller/admin/mf_product_export_listTest.php
@@ -3,13 +3,28 @@
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_export_listTest extends OxidTestCase
+class mf_product_export_listTest extends mf_product_admin_listTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->oView = new mf_product_export_list();
+        $this->oView->setVersionLayer($this->versionLayer);
+    }
+
     public function testRender()
     {
-        $oView = new mf_product_export_list();
-        $sTemplate = $oView->render();
+        $this->assertEquals('mf_product_export_list.tpl', $this->oView->render());
+    }
 
-        $this->assertEquals('mf_product_export_list.tpl', $sTemplate);
+    /**
+     * For the filter test on render() method.
+     *
+     * @return string
+     */
+    protected function getState()
+    {
+        return mfBepadoProduct::PRODUCT_STATE_EXPORTED;
     }
 }

--- a/tests/unit/controller/admin/mf_product_export_mainTest.php
+++ b/tests/unit/controller/admin/mf_product_export_mainTest.php
@@ -3,13 +3,85 @@
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_export_mainTest extends OxidTestCase
+class mf_product_export_mainTest extends BaseTestCase
 {
-    public function testRender()
-    {
-        $oView = new mf_product_export_main();
-        $sTemplate = $oView->render();
+    /**
+     * @var mf_product_export_main
+     */
+    protected $oView;
+    protected $oArticleHelper;
+    protected $oArticle;
+    protected $mfBepadoProduct;
+    protected $oxDb;
+    protected $oxArticleList;
+    protected $oxList;
+    protected $oxArticle;
 
+    public function setUp()
+    {
+        parent::setUp();
+        parent::prepareVersionLayerWithConfig();
+        $this->oArticleHelper = $this->getMockBuilder('mf_sdk_article_helper')->disableOriginalConstructor()->getMock();
+        $this->oArticle = $this->getMockBuilder('oxArticle')->disableOriginalConstructor()->getMock();
+        $this->oxDb = $this->getMockBuilder('oxLegacyDb')->disableOriginalConstructor()->getMock();
+        $this->versionLayer->expects($this->any())->method('getDb')->will($this->returnValue($this->oxDb));
+        $this->oxArticleList = $this->getMockBuilder('oxArticleList')->disableOriginalConstructor()->getMock();
+        $this->oxList = $this->getMockBuilder('oxList')->disableOriginalConstructor()->getMock();
+        $this->mfBepadoProduct = new mfBepadoProduct();
+        $this->oxArticle = $this->getMockBuilder('oxArticle')->disableOriginalConstructor()->getMock();
+        $this->oxArticleList->expects($this->any())->method('getBaseObject')->will($this->returnValue($this->oxArticle));
+        $this->oxList->expects($this->any())->method('getBaseObject')->will($this->returnValue($this->mfBepadoProduct));
+
+        $this->oView = new mf_product_export_main();
+        $this->oView->setVersionLayer($this->versionLayer);
+    }
+
+    public function testRenderProductExportedMain()
+    {
+        $oField = new oxField();
+        $oField->setValue('some value');
+        $this->oArticle->expects($this->once())->method('getLongDescription')->will($this->returnValue($oField));
+
+        $sTemplate = $this->oView->render();
+        $aViewData = $this->oView->getViewData();
+
+        $this->assertInstanceOf('mfBepadoProduct', $aViewData['edit']->mfBepadoProduct);
+        $this->assertInstanceOf('oxArticle', $aViewData['edit']->oxArticle);
+        $this->assertInstanceOf('mf_sdk_article_helper', $aViewData['edit']->oArticleHelper);
+        $this->assertNotNull($aViewData['editor']);
         $this->assertEquals('mf_product_export_main.tpl', $sTemplate);
+        $this->assertTrue($aViewData['updatelist']);
+    }
+
+    public function testProductExportedMainGetArticlesToExport()
+    {
+
+        $expectedClass = new stdClass();
+        $expectedClass->oxarticles__oxtitle = 'bla';
+
+        $this->oxArticleList
+            ->expects($this->once())
+            ->method('getArray')
+            ->will($this->returnValue(array('some-id' => $expectedClass, 'exported-id' => new stdClass())));
+        $this->oxList
+            ->expects($this->once())
+            ->method('getArray')
+            ->will($this->returnValue(array('exported-id' => 'blub')));
+
+        $expectedClass->pwrsearchval = 'bla';
+        $expectedResult = array('some-id' => $expectedClass);
+        $actualResult = $this->oView->getArticlesToExport();
+        $this->assertEquals($expectedResult, $actualResult);
+    }
+
+    protected function getObjectMapping()
+    {
+        return array(
+            'mf_sdk_article_helper' => $this->oArticleHelper,
+            'oxArticle'             => $this->oArticle,
+            'mfBepadoProduct'       => $this->mfBepadoProduct,
+            'oxArticleList'         => $this->oxArticleList,
+            'oxList'                => $this->oxList,
+        );
     }
 }

--- a/tests/unit/controller/admin/mf_product_import_listTest.php
+++ b/tests/unit/controller/admin/mf_product_import_listTest.php
@@ -3,13 +3,28 @@
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_import_listTest extends OxidTestCase
+class mf_product_import_listTest extends mf_product_admin_listTest
 {
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->oView = new mf_product_import_list();
+        $this->oView->setVersionLayer($this->versionLayer);
+    }
+
     public function testRender()
     {
-        $oView = new mf_product_import_list();
-        $sTemplate = $oView->render();
+        $this->assertEquals('mf_product_import_list.tpl', $this->oView->render());
+    }
 
-        $this->assertEquals('mf_product_import_list.tpl', $sTemplate);
+    /**
+     * For the filter test on render() method.
+     *
+     * @return string
+     */
+    protected function getState()
+    {
+        return mfBepadoProduct::PRODUCT_STATE_IMPORTED;
     }
 }

--- a/tests/unit/controller/admin/mf_product_import_mainTest.php
+++ b/tests/unit/controller/admin/mf_product_import_mainTest.php
@@ -3,13 +3,79 @@
 /**
  * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
  */
-class mf_product_import_mainTest extends OxidTestCase
+class mf_product_import_mainTest extends BaseTestCase
 {
+    protected $oArticleHelper;
+    protected $oVendorList;
+
+    /**
+     * @var mf_product_import_main
+     */
+    protected $oView;
+    protected $oArticle;
+    protected $mfBepadoProduct;
+
+    public function setUp()
+    {
+        parent::setup();
+        parent::prepareVersionLayerWithConfig();
+        $this->oArticleHelper = $this->getMockBuilder('mf_sdk_article_helper')->disableOriginalConstructor()->getMock();
+        $this->oVendorList = $this->getMockBuilder('oxVendorList')->disableOriginalConstructor()->getMock();
+        $this->oArticle = $this->getMockBuilder('oxArticle')->disableOriginalConstructor()->getMock();
+        $this->mfBepadoProduct = new mfBepadoProduct();
+
+        $this->oView = new mf_product_import_main();
+        $this->oView->setVersionLayer($this->versionLayer);
+    }
+
     public function testRender()
     {
-        $oView = new mf_product_import_main();
-        $sTemplate = $oView->render();
+        $oField = new oxField();
+        $oField->setValue('some value');
+        $this->oArticle->expects($this->once())->method('getLongDescription')->will($this->returnValue($oField));
+
+        $sTemplate = $this->oView->render();
+        $aViewData = $this->oView->getViewData();
+
+        $this->assertInstanceOf('mfBepadoProduct', $aViewData['edit']->mfBepadoProduct);
+        $this->assertInstanceOf('oxArticle', $aViewData['edit']->oxArticle);
+        $this->assertInstanceOf('mf_sdk_article_helper', $aViewData['edit']->oArticleHelper);
+        $this->assertNotNull($aViewData['editor']);
 
         $this->assertEquals('mf_product_import_main.tpl', $sTemplate);
+    }
+
+    public function testSave()
+    {
+        $aEditValues = array(
+            'oxArticle'       => array(
+                'oxarticles__'
+            ),
+            'mfBepadoProduct' => array(),
+        );
+        $this->oxidConfig
+            ->expects($this->once())
+            ->method('getRequestParameter')
+            ->with($this->equalTo('editval'))
+            ->will($this->returnValue($aEditValues));
+
+        $this->oArticle
+            ->expects($this->once())
+            ->method('assign')
+            ->with($this->equalTo($aEditValues['oxArticle']))
+            ;
+        $this->oArticle->expects($this->once())->method('save');
+
+        $this->oView->save();
+    }
+
+    protected function getObjectMapping()
+    {
+        return array(
+            'mf_sdk_article_helper' => $this->oArticleHelper,
+            'oxVendorList'          => $this->oVendorList,
+            'oxArticle'             => $this->oArticle,
+            'mfBepadoProduct'       => $this->mfBepadoProduct,
+        );
     }
 }

--- a/tests/unit/models/mfBepadoProductTest.php
+++ b/tests/unit/models/mfBepadoProductTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * @author Maximilian Berghoff <Maximilian.Berghoff@mayflower.de>
+ */
+class mfBepadoProductTest extends OxidTestCase
+{
+    public function tearDown()
+    {
+        $this->cleanUpTable('mfbepadoproducts');
+    }
+
+    public function testSetter()
+    {
+        $oBepadoProduct = new mfBepadoProduct();
+        $oBepadoProduct->setId('_prod-id');
+        $oBepadoProduct
+            ->setState(mfBepadoProduct::PRODUCT_STATE_EXPORTED)
+            ->setShopId('shop-id')
+            ->setProductSourceId('product-source-id')
+            ;
+        $oBepadoProduct->save();
+
+        $result = $this->getDb()->execute("SELECT * FROM mfbepadoproducts WHERE OXID ='_prod-id'");
+        $actualFields = $result->fields;
+        $expectedFields = array('_prod-id', 'product-source-id', 'shop-id', '1');
+
+        $this->assertEquals($expectedFields, $actualFields);
+    }
+
+    public function testGetter()
+    {
+        $this->getDb()->execute("INSERT INTO mfbepadoproducts (`OXID`, `p_source_id`, `shop_Id`, `state`) VALUES ('_prod-id', 'product-source-id', 'shop-id', '1')");
+
+        $oBepadoProduct = new mfBepadoProduct();
+        $oBepadoProduct->load('_prod-id');
+
+        $this->assertTrue($oBepadoProduct->isLoaded());
+        $this->assertEquals(1, $oBepadoProduct->getState());
+        $this->assertEquals('shop-id', $oBepadoProduct->getShopId());
+        $this->assertEquals('product-source-id', $oBepadoProduct->getProductSourceId());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     * @expectedExceptionMessage Product state 4 is not supported. Use one of 1,2.
+     */
+    public function testSetFalsyStateThrowsException()
+    {
+        $oBepadoProduct = new mfBepadoProduct();
+        $oBepadoProduct->setState(4);
+    }
+
+    public function testGetStateReturnStateNoneForNull()
+    {
+        $oBepadoProduct = new mfBepadoProduct();
+        $this->assertEquals(mfBepadoProduct::PRODUCT_STATE_NONE, $oBepadoProduct->getState());
+    }
+}

--- a/tests/unit/models/oxidProductFromShopTest.php
+++ b/tests/unit/models/oxidProductFromShopTest.php
@@ -367,7 +367,7 @@ class oxidProductFromShopTest extends BaseTestCase
         $this->oxDb
             ->expects($this->once())
             ->method('execute')
-            ->with('SELECT p_source_id FROM bepado_product_state WHERE state = 1')
+            ->with('SELECT p_source_id FROM mfbepadoproducts WHERE state = 1')
             ->will($this->returnValue($list));
         $ids = $this->productFromShop->getExportedProductIDs();
 


### PR DESCRIPTION
This PR solves #115 by exposing the exported/imported products and its main values in the bepado admin section. 

Tasks to be done:
* [x] replace "on the fly usage" `oxBase::init('...')` by  a model `mfBepadoProduct`
* [x] show all imported/exported products in the admin list view, separate import - export
* [x] make most common values editable on the `oxArticle` representation of an `mfBepadoProduct`
* [x] a delete button exists in the list for exported articles, which removes the exported property
* [x] add article to list of exported by "Create new" with a nice selection
* [x] show Shop name of exported/imported article in the list